### PR TITLE
Improvements to email layout

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -7,6 +7,11 @@ blomstra-digest:
         daily: Daily digest
         weekly: Weekly digest
   email:
-    subject: Your Flarum notification digest
-    greeting: Hey {recipient_display_name}!
-    footer: You can change your digest frequency setting in the Flarum user settings at any time.
+    digest:
+      subject: Your Flarum notification digest
+      greeting: Hey {recipient_display_name}!
+      nonDiscussionGroup: Other notifications
+      footer: You can change your digest frequency setting in the Flarum user settings at any time.
+    newPost:
+      message: "{poster_display_name} made a post in a discussion you're following:"
+      link: View post

--- a/src/Mail/Group.php
+++ b/src/Mail/Group.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of blomstra/digest.
+ *
+ * Copyright (c) 2022 Team Blomstra.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Blomstra\Digest\Mail;
+
+use Flarum\Discussion\Discussion;
+
+/**
+ * A helper class that is passed to the view.
+ */
+class Group
+{
+    /**
+     * @var Discussion|null
+     */
+    public $discussion;
+
+    /**
+     * @var Notification[]
+     */
+    public $notifications = [];
+
+    public function __construct(Discussion $discussion = null)
+    {
+        $this->discussion = $discussion;
+    }
+}

--- a/src/Mail/Notification.php
+++ b/src/Mail/Notification.php
@@ -57,7 +57,7 @@ class Notification
     }
 
     /**
-     * HTML output for that notification
+     * HTML output for that notification.
      */
     public function render(User $user): string
     {
@@ -65,7 +65,7 @@ class Notification
 
         $html = resolve(Factory::class)->make($viewName, [
             'blueprint' => $this->blueprint,
-            'user' => $user,
+            'user'      => $user,
         ])->render();
 
         // Remove greeting line

--- a/src/Mail/Notification.php
+++ b/src/Mail/Notification.php
@@ -14,6 +14,9 @@ namespace Blomstra\Digest\Mail;
 use Carbon\Carbon;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\MailableInterface;
+use Flarum\User\User;
+use Illuminate\Support\Arr;
+use Illuminate\View\Factory;
 
 /**
  * A helper class that is passed to the view.
@@ -30,9 +33,47 @@ class Notification
      */
     public $date;
 
+    const VIEWS_WITH_GREETINGS = [
+        'flarum-mentions::emails.postMentioned',
+        'flarum-mentions::emails.userMentioned',
+        'flarum-subscriptions::emails.newPost',
+    ];
+
+    const VIEW_OVERRIDES = [
+        'flarum-subscriptions::emails.newPost' => 'blomstra-digest::emails.newPost',
+    ];
+
     public function __construct(BlueprintInterface $blueprint, Carbon $date)
     {
         $this->blueprint = $blueprint;
         $this->date = $date;
+    }
+
+    protected function viewName(): string
+    {
+        $originalViewName = Arr::get($this->blueprint->getEmailView(), 'text');
+
+        return Arr::get(self::VIEW_OVERRIDES, $originalViewName, $originalViewName);
+    }
+
+    /**
+     * HTML output for that notification
+     */
+    public function render(User $user): string
+    {
+        $viewName = $this->viewName();
+
+        $html = resolve(Factory::class)->make($viewName, [
+            'blueprint' => $this->blueprint,
+            'user' => $user,
+        ])->render();
+
+        // Remove greeting line
+        if (in_array($viewName, self::VIEWS_WITH_GREETINGS)) {
+            // Remove first 2 lines of string
+            $html = explode("\n", $html, 3)[2] ?? '';
+        }
+
+        return $html;
     }
 }

--- a/src/Mail/Notification.php
+++ b/src/Mail/Notification.php
@@ -50,7 +50,7 @@ class Notification
     }
 
     /**
-     * Returns the view to use as an array where [0] is text or html and [1] is the view name
+     * Returns the view to use as an array where [0] is text or html and [1] is the view name.
      */
     protected function viewName(): array
     {
@@ -70,7 +70,7 @@ class Notification
             return [$mode, $originalViewName];
         }
 
-        throw new \Exception('Could not find an email view for ' . get_class($this->blueprint));
+        throw new \Exception('Could not find an email view for '.get_class($this->blueprint));
     }
 
     /**

--- a/src/Mail/SendDigestToUser.php
+++ b/src/Mail/SendDigestToUser.php
@@ -77,7 +77,7 @@ class SendDigestToUser extends AbstractJob
 
             if ($model instanceof Discussion) {
                 $discussion = $model;
-            } else if ($model instanceof Post) {
+            } elseif ($model instanceof Post) {
                 $discussion = $model->discussion;
             }
 
@@ -97,7 +97,7 @@ class SendDigestToUser extends AbstractJob
             ],
             [
                 'groupedNotifications' => $discussions,
-                'user' => $this->user,
+                'user'                 => $this->user,
             ],
             function (Message $message) use ($translator) {
                 $message->to($this->user->email, $this->user->display_name)

--- a/views/emails/digest.blade.php
+++ b/views/emails/digest.blade.php
@@ -1,14 +1,37 @@
-{!! $translator->trans('blomstra-digest.email.greeting', [
-'{recipient_display_name}' => $user->display_name,
-]) !!}
+<!doctype html>
+<html>
+<body>
 
-@foreach($notifications as $notification)
-## {{ $notification->date->format('Y-m-d H:i') }} - {{ $notification->blueprint->getEmailSubject($translator) }}
+<p>
+    {{ $translator->trans('blomstra-digest.email.digest.greeting', [
+        '{recipient_display_name}' => $user->display_name,
+    ]) }}
+</p>
 
-@php($notificationEmailView = \Illuminate\Support\Arr::get($notification->blueprint->getEmailView(), 'text'))
-@include($notificationEmailView, ['blueprint' => $notification->blueprint])
+@foreach($groupedNotifications as $group)
+    <h2>
+        @if ($group->discussion)
+            <a href="{{ $url->to('forum')->route('discussion', [
+                'id' =>  resolve(\Flarum\Http\SlugManager::class)->forResource(\Flarum\Discussion\Discussion::class)->toSlug($group->discussion),
+            ]) }}">
+                {{ $group->discussion->title }}
+            </a>
+        @else
+            {{ $translator->trans('blomstra-digest.email.digest.nonDiscussionGroup') }}
+        @endif
+    </h2>
 
----
+    @foreach($group->notifications as $notification)
+        <h3>{{ $notification->date->format('Y-m-d H:i') }}
+            - {{ $notification->blueprint->getEmailSubject($translator) }}</h3>
+
+        {!! $notification->render($user) !!}
+
+        <hr>
+    @endforeach
 @endforeach
 
-{!! $translator->trans('blomstra-digest.email.footer') !!}
+<p>{{ $translator->trans('blomstra-digest.email.digest.footer') }}</p>
+
+</body>
+</html>

--- a/views/emails/newPost.blade.php
+++ b/views/emails/newPost.blade.php
@@ -1,0 +1,16 @@
+<p>{{ $translator->trans('blomstra-digest.email.newPost.message', [
+    '{poster_display_name}' => $blueprint->post->user->display_name,
+]) }}</p>
+
+@if ($blueprint->post instanceof \Flarum\Post\CommentPost)
+    {!! $blueprint->post->formatContent() !!}
+@else
+    {{ $blueprint->post->content }}
+@endif
+
+<a href="{{ $url->to('forum')->route('discussion', [
+                'id' =>  resolve(\Flarum\Http\SlugManager::class)->forResource(\Flarum\Discussion\Discussion::class)->toSlug($blueprint->post->discussion),
+                'near' => $blueprint->post->number,
+            ]) }}">
+    {{ $translator->trans('blomstra-digest.email.newPost.link') }}
+</a>


### PR DESCRIPTION
This is the start from our list of wanted improvements.

The email is now HTML but I didn't include any styling.

Notifications are now grouped by discussion, with the clickable discussion title above each group.

The notification heading has not been customized for now (date + original mail subject).

The notification body can be switched to a custom view. For now I have replaced the mention's `newPost` blade template with a custom one that includes HTML.

I have implemented a list of views that must be trimmed of their greetings. This might end up not being very useful if we also replace every known view with a custom HTML blade template already.

I will still push a few more things.

![image](https://user-images.githubusercontent.com/5264300/169116203-1b66de8c-e665-47f4-bd87-2b3411a4e52a.png)
