### PR TITLE
Include every post notification from Subscriptions in digest

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -13,6 +13,7 @@ namespace Blomstra\Digest;
 
 use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\Extend;
+use Flarum\Post\Event\Posted;
 use Flarum\User\Event\Saving;
 use Flarum\User\User;
 use Illuminate\Console\Scheduling\Event;
@@ -32,7 +33,8 @@ return [
         ->namespace('blomstra-digest', __DIR__.'/views'),
 
     (new Extend\Event())
-        ->listen(Saving::class, Listener\SaveUser::class),
+        ->listen(Saving::class, Listener\SaveUser::class)
+        ->listen(Posted::class, Listener\SendFollowReplyNotificationEveryTime::class),
 
     (new Extend\ApiSerializer(CurrentUserSerializer::class))
         ->attribute('digestFrequency', function ($serializer, User $user) {

--- a/src/Job/SendReplyNotificationToOthers.php
+++ b/src/Job/SendReplyNotificationToOthers.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of blomstra/digest.
+ *
+ * Copyright (c) 2022 Team Blomstra.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Blomstra\Digest\Job;
 
 use Flarum\Notification\NotificationSyncer;
@@ -13,7 +22,7 @@ use Illuminate\Queue\SerializesModels;
  * Modified version of Flarum\Subscriptions\Job\SendReplyNotification (original job still runs as well)
  * This code will send the notification to all users who weren't already notified by the original job
  * TODO: The original code was modified in https://github.com/flarum/framework/pull/3445 which will be released in 1.3.1
- * This will require some kind of detection of Flarum 1.2 vs 1.3
+ * This will require some kind of detection of Flarum 1.2 vs 1.3.
  */
 class SendReplyNotificationToOthers implements ShouldQueue
 {
@@ -31,7 +40,7 @@ class SendReplyNotificationToOthers implements ShouldQueue
     protected $lastPostNumber;
 
     /**
-     * @param Post $post
+     * @param Post     $post
      * @param int|null $lastPostNumber
      */
     public function __construct(Post $post, $lastPostNumber)

--- a/src/Job/SendReplyNotificationToOthers.php
+++ b/src/Job/SendReplyNotificationToOthers.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Blomstra\Digest\Job;
+
+use Flarum\Notification\NotificationSyncer;
+use Flarum\Post\Post;
+use Flarum\Subscriptions\Notification\NewPostBlueprint;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Modified version of Flarum\Subscriptions\Job\SendReplyNotification (original job still runs as well)
+ * This code will send the notification to all users who weren't already notified by the original job
+ * TODO: The original code was modified in https://github.com/flarum/framework/pull/3445 which will be released in 1.3.1
+ * This will require some kind of detection of Flarum 1.2 vs 1.3
+ */
+class SendReplyNotificationToOthers implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * @var int
+     */
+    protected $lastPostNumber;
+
+    /**
+     * @param Post $post
+     * @param int|null $lastPostNumber
+     */
+    public function __construct(Post $post, $lastPostNumber)
+    {
+        $this->post = $post;
+        $this->lastPostNumber = $lastPostNumber;
+    }
+
+    public function handle(NotificationSyncer $notifications)
+    {
+        $post = $this->post;
+        $discussion = $post->discussion;
+
+        $notify = $discussion->readers()
+            ->where('users.id', '!=', $post->user_id)
+            ->whereNotNull('users.digest_frequency') // Only do this for users who enabled digest
+            ->where('discussion_user.subscription', 'follow')
+            ->where('discussion_user.last_read_post_number', '!=', $this->lastPostNumber) // Opposite of original condition
+            ->get();
+
+        $notifications->sync(
+            new NewPostBlueprint($post),
+            $notify->all()
+        );
+    }
+}

--- a/src/Listener/SendFollowReplyNotificationEveryTime.php
+++ b/src/Listener/SendFollowReplyNotificationEveryTime.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of blomstra/digest.
+ *
+ * Copyright (c) 2022 Team Blomstra.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Blomstra\Digest\Listener;
 
 use Blomstra\Digest\Job\SendReplyNotificationToOthers;
@@ -9,7 +18,7 @@ use Illuminate\Contracts\Queue\Queue;
 
 /**
  * Same as Flarum\Subscriptions\Listener\SendNotificationWhenReplyIsPosted to dispatch the modified job
- * With added check for whether the extension is enabled
+ * With added check for whether the extension is enabled.
  */
 class SendFollowReplyNotificationEveryTime
 {

--- a/src/Listener/SendFollowReplyNotificationEveryTime.php
+++ b/src/Listener/SendFollowReplyNotificationEveryTime.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Blomstra\Digest\Listener;
+
+use Blomstra\Digest\Job\SendReplyNotificationToOthers;
+use Flarum\Extension\ExtensionManager;
+use Flarum\Post\Event\Posted;
+use Illuminate\Contracts\Queue\Queue;
+
+/**
+ * Same as Flarum\Subscriptions\Listener\SendNotificationWhenReplyIsPosted to dispatch the modified job
+ * With added check for whether the extension is enabled
+ */
+class SendFollowReplyNotificationEveryTime
+{
+    /**
+     * @var Queue
+     */
+    protected $queue;
+
+    /**
+     * @var ExtensionManager
+     */
+    protected $manager;
+
+    public function __construct(Queue $queue, ExtensionManager $manager)
+    {
+        $this->queue = $queue;
+        $this->manager = $manager;
+    }
+
+    public function handle(Posted $event)
+    {
+        if (!$this->manager->isEnabled('flarum-subscriptions')) {
+            return;
+        }
+
+        $this->queue->push(
+            new SendReplyNotificationToOthers($event->post, $event->post->discussion->last_post_number)
+        );
+    }
+}


### PR DESCRIPTION
Unfortunately there is no generalized solution for this. This fix is specifically for Subscriptions extension. If other extensions also suppress repeated notifications they will likely require specific code for each.

This code is impacted by the Flarum 1.3 issue due to the change of the last post number computation. I can't account for it right now since the fix hasn't been released yet. We could keep this PR on hold until Flarum 1.3.1 is released and I can make it work on both 1.2 and 1.3 https://github.com/flarum/framework/pull/3445

This PR was tested on Flarum 1.2. It will probably work as expected on Flarum 1.3.0 but likely cause the first notification to be duplicated in 1.3.1