### PR TITLE
Add summary to digest and remove some titles

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -10,6 +10,7 @@ blomstra-digest:
     digest:
       subject: Your Flarum notification digest
       greeting: Hey {recipient_display_name}!
+      summary: You have {notificationCount} new notifications in {discussionCount} discussions.
       nonDiscussionGroup: Other notifications
       footer: You can change your digest frequency setting in the Flarum user settings at any time.
     newPost:

--- a/src/Mail/Notification.php
+++ b/src/Mail/Notification.php
@@ -12,8 +12,10 @@
 namespace Blomstra\Digest\Mail;
 
 use Carbon\Carbon;
+use Flarum\Locale\Translator;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\MailableInterface;
+use Flarum\Subscriptions\Notification\NewPostBlueprint;
 use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Illuminate\View\Factory;
@@ -41,6 +43,12 @@ class Notification
 
     const VIEW_OVERRIDES = [
         'flarum-subscriptions::emails.newPost' => 'blomstra-digest::emails.newPost',
+    ];
+
+    // Notifications where we know the mail subject is redundant with the information we already display
+    // Those notifications will only have a date and no additional title
+    const BLUEPRINT_REMOVE_SUBJECT = [
+        NewPostBlueprint::class,
     ];
 
     public function __construct(BlueprintInterface $blueprint, Carbon $date)
@@ -97,5 +105,15 @@ class Notification
         }
 
         return $html;
+    }
+
+    public function title(Translator $translator): string {
+        $title = $this->date->format('Y-m-d H:i');
+
+        if (!in_array(get_class($this->blueprint), self::BLUEPRINT_REMOVE_SUBJECT)) {
+            $title .= ' - '.$this->blueprint->getEmailSubject($translator);
+        }
+
+        return $title;
     }
 }

--- a/src/Mail/Notification.php
+++ b/src/Mail/Notification.php
@@ -107,7 +107,8 @@ class Notification
         return $html;
     }
 
-    public function title(Translator $translator): string {
+    public function title(Translator $translator): string
+    {
         $title = $this->date->format('Y-m-d H:i');
 
         if (!in_array(get_class($this->blueprint), self::BLUEPRINT_REMOVE_SUBJECT)) {

--- a/src/Mail/SendDigestToUser.php
+++ b/src/Mail/SendDigestToUser.php
@@ -56,6 +56,9 @@ class SendDigestToUser extends AbstractJob
 
         $discussions = [];
 
+        $discussionCount = 0;
+        $notificationCount = 0;
+
         foreach ($queuedBlueprints as $queuedBlueprint) {
             /**
              * @var BlueprintInterface $blueprint
@@ -86,9 +89,15 @@ class SendDigestToUser extends AbstractJob
             if (!Arr::exists($discussions, $discussionId)) {
                 // TODO: place "other" key at the end of the array
                 $discussions[$discussionId] = new Group($discussion);
+
+                if ($discussionId) {
+                    $discussionCount++;
+                }
             }
 
             $discussions[$discussionId]->notifications[] = new Notification($blueprint, $queuedBlueprint->date);
+
+            $notificationCount++;
         }
 
         $mailer->send(
@@ -96,6 +105,8 @@ class SendDigestToUser extends AbstractJob
                 'html' => 'blomstra-digest::emails.digest',
             ],
             [
+                'discussionCount'      => $discussionCount,
+                'notificationCount'    => $notificationCount,
                 'groupedNotifications' => $discussions,
                 'user'                 => $this->user,
             ],

--- a/views/emails/digest.blade.php
+++ b/views/emails/digest.blade.php
@@ -8,6 +8,13 @@
     ]) }}
 </p>
 
+<p>
+    {{ $translator->trans('blomstra-digest.email.digest.summary', [
+        '{discussionCount}' => $discussionCount,
+        '{notificationCount}' => $notificationCount,
+    ]) }}
+</p>
+
 @foreach($groupedNotifications as $group)
     <h2>
         @if ($group->discussion)
@@ -22,8 +29,7 @@
     </h2>
 
     @foreach($group->notifications as $notification)
-        <h3>{{ $notification->date->format('Y-m-d H:i') }}
-            - {{ $notification->blueprint->getEmailSubject($translator) }}</h3>
+        <h3>{{ $notification->title($translator) }}</h3>
 
         {!! $notification->render($user) !!}
 


### PR DESCRIPTION
This PR adds a count summary in the beginning of the digest.

It also adds code to hide select titles. Currently I only added the discussion subscription email to the list of hidden titles, but I think I could hide most of the known notification subjects.

My worry with hiding everything by default is that it could render some notifications from extension we aren't aware of unreadable.

![image](https://user-images.githubusercontent.com/5264300/172063569-73b12694-3df0-4cd9-901d-f517d5086b81.png)
