### PR TITLE
Fix single digest on async queues by forcing Subscriptions job to sync

### DIFF
--- a/src/Listener/SendNotificationWhenReplyIsPostedOverride.php
+++ b/src/Listener/SendNotificationWhenReplyIsPostedOverride.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of blomstra/digest.
+ *
+ * Copyright (c) 2022 Team Blomstra.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Blomstra\Digest\Listener;
+
+use Flarum\Post\Event\Posted;
+use Flarum\Subscriptions\Job\SendReplyNotification;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\SyncQueue;
+
+// Same as original from flarum/subscriptions except we force it to use sync queue
+class SendNotificationWhenReplyIsPostedOverride
+{
+    /**
+     * @var Queue
+     */
+    protected $queue;
+
+    public function __construct(SyncQueue $queue, Container $container)
+    {
+        $this->queue = $queue;
+        $this->queue->setContainer($container);
+    }
+
+    public function handle(Posted $event)
+    {
+        $this->queue->push(
+            new SendReplyNotification($event->post, $event->post->discussion->last_post_number)
+        );
+    }
+}

--- a/src/Providers/DigestServiceProvider.php
+++ b/src/Providers/DigestServiceProvider.php
@@ -11,13 +11,16 @@
 
 namespace Blomstra\Digest\Providers;
 
+use Blomstra\Digest\Listener\SendNotificationWhenReplyIsPostedOverride;
 use Blomstra\Digest\MemoryQueue;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Subscriptions\Listener\SendNotificationWhenReplyIsPosted;
 
 class DigestServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
         $this->container->singleton(MemoryQueue::class);
+        $this->container->bind(SendNotificationWhenReplyIsPosted::class, SendNotificationWhenReplyIsPostedOverride::class);
     }
 }


### PR DESCRIPTION
I don't find this solution super pretty but it's the only way I could find to make the "single digest" feature work without completely re-implementing how it works.

The `flarum/subscriptions` extension dispatches `SendReplyNotification` to the default queue, so when an async queue is used on Flarum, the job gets sent to the queue and "escapes" the middleware-based single digest grouping. This PR changes this by forcing that particular job to always run on the `SyncQueue` no matter what the default queue is.

Unfortunately there's no way to do this only for users who don't have a digest and it's a bit difficult to only do it when the single digest feature is enabled, since the override happens so early in the container, and adding additional logic to switch queue in the job itself might be more complex that necessary (?)

I don't think the performance impact should be too big. It causes one more database request in sync for each `Posting` event (the query in the job), which probably isn't a big deal, but the impact is probably in the notification syncer where there's one or 2 database requests for each subscriber of the discussion to update the `notifications` table. The mails themselves are still queued with `Blomstra\Digest\Notification\SendSingleDigestJob` so the request isn't slowed down by SMTP, only the web notification updates.