### PR TITLE
Exclude select blueprints from digest and integrate FoF Subscribed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg) [![Latest Stable Version](https://img.shields.io/packagist/v/blomstra/digest.svg)](https://packagist.org/packages/blomstra/digest) [![Total Downloads](https://img.shields.io/packagist/dt/blomstra/digest.svg)](https://packagist.org/packages/blomstra/digest)
 
-A [Flarum](http://flarum.org) extension. Email digests for your forum users
+A [Flarum](https://flarum.org/) extension. Email digests for your forum users.
+
+2 frequencies are included by default: daily and weekly.
+The sending is implemented into the Flarum scheduler, so [it's the only thing you need to configure](https://docs.flarum.org/console#schedulerun).
+
+You can optionally enable the "Single Digest" feature, which will bundle immediate notifications into a template similar to the digest for users who didn't configure a digest frequency.
+This feature will group all different notifications sent during a single Flarum request lifecycle together, even if some are processed on an asynchronous queue.
+If some jobs are asynchronous, all notifications for that request will be held on a queue until all jobs have finished processing so that a single email can be generated for each user.
 
 ## Installation
 
@@ -19,6 +26,19 @@ composer update blomstra/digest
 php flarum migrate
 php flarum cache:clear
 ```
+
+## Excluded Blueprints
+
+A list of blueprints are excluded from both the Scheduled and Single Digests.
+These blueprints will always use the built-in Flarum email template and send immediately in their own email.
+
+The following blueprints are in the excluded list:
+
+- `flarum/suspend`: all notifications
+- `fof/byobu`: all notifications
+- `fof/subscribed`: post flagged
+
+The excluded list can be customized by developers via the container binding `blomstra.digest.excludedBlueprints`.
 
 ## Links
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,14 @@
     "require": {
         "flarum/core": "^1.2.0"
     },
+    "require-dev": {
+        "flarum/mentions": "*",
+        "flarum/subscriptions": "*",
+        "flarum/suspend": "*",
+        "fof/byobu": "*",
+        "fof/follow-tags": "*",
+        "fof/subscribed": "*"
+    },
     "support": {
         "email": "helpdesk@blomstra.net",
         "forum": "https://blomstra.community/t/ext-digest",

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -21,9 +21,11 @@ blomstra-digest:
         followed: You follow this discussion
         tagFollowed: You follow this tag
         tagLurked: You lurk this tag
+        globalSubscribed: You subscribed to new discussions globally
         visit: Go to discussion
       post:
         mentioned: You were mentioned
+        globalSubscribed: You subscribed to new posts globally
     single:
       summary: New notifications for this discussion
       footer: You can change your notification setting in the Flarum user settings at any time.

--- a/src/Mail/Discussion.php
+++ b/src/Mail/Discussion.php
@@ -42,6 +42,11 @@ class Discussion
     public $isTagLurked = false;
 
     /**
+     * @var bool Whether this discussion was notified through fof/subscribed global subscription
+     */
+    public $isGlobalSubscribed = false;
+
+    /**
      * @var Post[] Whether this discussion is part of a flarum/subscriptions notification
      */
     protected $importantPosts = [];
@@ -96,7 +101,7 @@ class Discussion
                 }
 
                 // The tag is marked as followed if there was a new discussion notification. In this case we'll include the first post
-                if ($this->isTagFollowed) {
+                if ($this->isTagFollowed || $this->isGlobalSubscribed) {
                     $query->orWhere('number', 1);
                 }
             })

--- a/src/Mail/Post.php
+++ b/src/Mail/Post.php
@@ -13,12 +13,22 @@ namespace Blomstra\Digest\Mail;
 
 /**
  * Helper class to define why a post is part of the digest.
- *
- * @property \Flarum\Post\Post $post        The post model. Will be set by the Discussion helper automatically
- * @property bool              $isMentioned Whether that post is part of a mention notification
  */
 class Post
 {
+    /**
+     * @var \Flarum\Post\Post The post model. Will be set by the Discussion helper automatically
+     */
     public $post = null;
+
+    /**
+     * @var bool Whether that post is part of a mention notification
+     */
     public $isMentioned = false;
+
+    /**
+     * @var bool Whether this post was notified through fof/subscribed global subscription
+     */
+    public $isGlobalSubscribed = false;
+
 }

--- a/src/Mail/Post.php
+++ b/src/Mail/Post.php
@@ -30,5 +30,4 @@ class Post
      * @var bool Whether this post was notified through fof/subscribed global subscription
      */
     public $isGlobalSubscribed = false;
-
 }

--- a/src/Provider/DigestServiceProvider.php
+++ b/src/Provider/DigestServiceProvider.php
@@ -12,12 +12,36 @@
 namespace Blomstra\Digest\Provider;
 
 use Blomstra\Digest\Batch\BatchJobAggregator;
+use Blomstra\Digest\Notification\EmailDigestNotificationDriver;
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Suspend\Notification\UserSuspendedBlueprint;
+use Flarum\Suspend\Notification\UserUnsuspendedBlueprint;
+use FoF\Byobu\Notifications as ByobuNotifications;
+use FoF\Subscribed\Blueprints\PostFlaggedBlueprint;
 
 class DigestServiceProvider extends AbstractServiceProvider
 {
     public function register()
     {
+        // These blueprints will never be batched or templated by our extension
+        // and will continue to be sent immediately
+        $this->container->instance('blomstra.digest.excludedBlueprints', [
+            UserSuspendedBlueprint::class,
+            UserUnsuspendedBlueprint::class,
+            ByobuNotifications\DiscussionAddedBlueprint::class,
+            ByobuNotifications\DiscussionCreatedBlueprint::class,
+            ByobuNotifications\DiscussionMadePublicBlueprint::class,
+            ByobuNotifications\DiscussionRecipientRemovedBlueprint::class,
+            ByobuNotifications\DiscussionRepliedBlueprint::class,
+            PostFlaggedBlueprint::class,
+        ]);
+
+        $this->container->when(EmailDigestNotificationDriver::class)
+            ->needs('$excludedBlueprints')
+            ->give(function (): array {
+                return $this->container->make('blomstra.digest.excludedBlueprints');
+            });
+
         $this->container->singleton(BatchJobAggregator::class);
     }
 }

--- a/views/emails/content/discussion.blade.php
+++ b/views/emails/content/discussion.blade.php
@@ -61,6 +61,10 @@ if (resolve(\Flarum\Extension\ExtensionManager::class)->isEnabled('flarum-tags')
         <p style="color: rgb(102, 124, 153);">{{ $translator->trans('blomstra-digest.email.digest.discussion.tagLurked') }}</p>
     @endif
 
+    @if ($discussion->isGlobalSubscribed)
+        <p style="color: rgb(102, 124, 153);">{{ $translator->trans('blomstra-digest.email.digest.discussion.globalSubscribed') }}</p>
+    @endif
+
     @foreach($discussion->relevantPosts($user) as $post)
         <div class="Post">
             @php($author = $post->post->user)
@@ -86,6 +90,10 @@ if (resolve(\Flarum\Extension\ExtensionManager::class)->isEnabled('flarum-tags')
 
             @if ($post->isMentioned)
                 <p style="color: rgb(102, 124, 153);">{{ $translator->trans('blomstra-digest.email.digest.post.mentioned') }}</p>
+            @endif
+
+            @if ($post->isGlobalSubscribed)
+                <p style="color: rgb(102, 124, 153);">{{ $translator->trans('blomstra-digest.email.digest.post.globalSubscribed') }}</p>
             @endif
 
             <div class="PostBody">


### PR DESCRIPTION
It was easier to do both things together since I also added all dev imports to make type-checking easier on the PHP side.

We could in theory add an extender for the excluded digests feature. For now it's just a container binding that custom integrations can already tap into if needed.