### PR TITLE
Use Flarum 1.5 notify_for_all_posts

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -1,0 +1,4 @@
+// Flarum doesn't have a disabled state for the Checkbox
+.item-notifyForAllPosts .Checkbox.disabled {
+  opacity: 0.5;
+}

--- a/migrations/2022_09_19_000000_alter_users_add_last_digest_column.php
+++ b/migrations/2022_09_19_000000_alter_users_add_last_digest_column.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of blomstra/digest.
+ *
+ * Copyright (c) 2022 Team Blomstra.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('users', [
+    // Used to filter out content that was already included in the previous digest
+    'last_digest_sent_at' => ['timestamp', 'nullable' => true],
+]);

--- a/src/Mail/SendDigestToUser.php
+++ b/src/Mail/SendDigestToUser.php
@@ -115,6 +115,12 @@ class SendDigestToUser extends AbstractJob
             }
         );
 
+        // If this was a scheduled digest, store the date to the user model
+        if (!$this->batch) {
+            $this->user->last_digest_sent_at = $processingNow;
+            $this->user->save();
+        }
+
         // Now that we are done, we can delete all queued blueprints that were just sent
         $this->blueprintQuery($processingNow)->delete();
     }


### PR DESCRIPTION
This PR does 2 things:

- Prevent posts to be repeated in subsequent digests if the discussion stays unread when using "Notify for all posts" on Flarum 1.5
- Force "Notify for all posts" to automatically enable with digest since it will most likely be the desired output

If we go this route we can definitely close #3 This approach has the benefit of not requireing to override he SendReplyNotification job from Flarum Subscriptions.

Ideally I wanted to do this entirely server-side and keep the previous user preference for when they disable digest, but there's just no way to hook into the preferences API to do that. So instead I have to change the actual setting on the user.

I experimented with storing the previous preference value in a second preference but it just adds too much complexity. Instead I simply revert "Notify for all posts" to disabled when you disable digest.

Existing users from Flarum 1.4 won't have "Notify for all posts" enabled. They can still enable it in the setting, in which case it'll become disabled in "on" position, or it will be enabled for them the next time the digest send command runs.