### PR TITLE
Empty digests and fof bugfix

### DIFF
--- a/src/Mail/DiscussionList.php
+++ b/src/Mail/DiscussionList.php
@@ -71,7 +71,7 @@ class DiscussionList
         }
 
         if ($blueprint instanceof FoFFollowTags\NewPostBlueprint) {
-            $this->discussion($blueprint->getSubject()->discussion)->isTagLurked = true;
+            $this->discussion($blueprint->getSubject())->isTagLurked = true;
 
             return true;
         }


### PR DESCRIPTION
I was not able to confirm this was the cause for the emails containing zero notifications, but it's the only thing I think could have generated them.

I also included a fix in case the subject is null instead of an Eloquent model. I don't think any extension does that but it would cause issues if it happened.

And finally I included a bugfix for FoF Follow Tags which crashed my site during the tests.